### PR TITLE
feat(fk-001): add SwiftData models and legacy feed migration

### DIFF
--- a/Familienkalendar/ContentView.swift
+++ b/Familienkalendar/ContentView.swift
@@ -7,11 +7,16 @@
 
 import SwiftUI
 import EventKit
+import SwiftData
 import Combine
 
 struct ContentView: View {
-    @StateObject private var viewModel = FamilyCalendarViewModel()
+    @StateObject private var viewModel: FamilyCalendarViewModel
     @State private var showSettings = false
+
+    init(modelContext: ModelContext) {
+        _viewModel = StateObject(wrappedValue: FamilyCalendarViewModel(modelContext: modelContext))
+    }
 
     var body: some View {
         ZStack {
@@ -323,9 +328,9 @@ final class FamilyCalendarViewModel: ObservableObject {
     @Published var errorMessage: String?
 
     private let eventStore = EKEventStore()
+    private let remoteFeedStore: RemoteFeedStore
     private var didBootstrap = false
     private let localSelectionKey = "selectedLocalCalendarIDs"
-    private let remoteFeedsKey = "remoteICSFeeds"
     private let palette: [Color] = [
         Color(red: 0.90, green: 0.72, blue: 0.78),
         Color(red: 0.75, green: 0.84, blue: 0.72),
@@ -335,6 +340,10 @@ final class FamilyCalendarViewModel: ObservableObject {
         Color(red: 0.88, green: 0.77, blue: 0.93),
         Color(red: 0.91, green: 0.78, blue: 0.71)
     ]
+
+    init(modelContext: ModelContext) {
+        self.remoteFeedStore = RemoteFeedStore(modelContext: modelContext)
+    }
 
     var columns: [CalendarColumn] {
         let local = localCalendars
@@ -490,9 +499,11 @@ final class FamilyCalendarViewModel: ObservableObject {
             selectedLocalIDs = Set(array)
         }
 
-        if let data = UserDefaults.standard.data(forKey: remoteFeedsKey),
-           let feeds = try? JSONDecoder().decode([RemoteFeed].self, from: data) {
-            remoteFeeds = feeds
+        do {
+            try remoteFeedStore.migrateLegacyIfNeeded()
+            remoteFeeds = try remoteFeedStore.loadFeeds()
+        } catch {
+            errorMessage = "Gespeicherte Feed-Daten konnten nicht geladen werden."
         }
     }
 
@@ -503,8 +514,10 @@ final class FamilyCalendarViewModel: ObservableObject {
     }
 
     private func persistRemoteFeeds() {
-        if let data = try? JSONEncoder().encode(remoteFeeds) {
-            UserDefaults.standard.set(data, forKey: remoteFeedsKey)
+        do {
+            try remoteFeedStore.saveFeeds(remoteFeeds)
+        } catch {
+            errorMessage = "Feed-Änderungen konnten nicht gespeichert werden."
         }
     }
 

--- a/Familienkalendar/DomainModels.swift
+++ b/Familienkalendar/DomainModels.swift
@@ -1,0 +1,109 @@
+import Foundation
+import SwiftData
+
+@Model
+final class PersonModel {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var colorHex: String
+    var role: String
+
+    init(id: UUID = UUID(), name: String, colorHex: String = "#6A4E7A", role: String = "parent") {
+        self.id = id
+        self.name = name
+        self.colorHex = colorHex
+        self.role = role
+    }
+}
+
+@Model
+final class CalendarEventModel {
+    @Attribute(.unique) var id: String
+    var title: String
+    var startDate: Date
+    var endDate: Date
+    var sourceID: String
+    var isAllDay: Bool
+
+    init(
+        id: String = UUID().uuidString,
+        title: String,
+        startDate: Date,
+        endDate: Date,
+        sourceID: String,
+        isAllDay: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.startDate = startDate
+        self.endDate = endDate
+        self.sourceID = sourceID
+        self.isAllDay = isAllDay
+    }
+}
+
+@Model
+final class RemoteFeedModel {
+    @Attribute(.unique) var id: String
+    var name: String
+    var urlString: String
+    var isEnabled: Bool
+    var createdAt: Date
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        urlString: String,
+        isEnabled: Bool = true,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.urlString = urlString
+        self.isEnabled = isEnabled
+        self.createdAt = createdAt
+    }
+}
+
+@Model
+final class TaskItemModel {
+    @Attribute(.unique) var id: UUID
+    var title: String
+    var dueDate: Date?
+    var isDone: Bool
+    var assigneeID: UUID?
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        dueDate: Date? = nil,
+        isDone: Bool = false,
+        assigneeID: UUID? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.dueDate = dueDate
+        self.isDone = isDone
+        self.assigneeID = assigneeID
+    }
+}
+
+@Model
+final class ReminderRuleModel {
+    @Attribute(.unique) var id: UUID
+    var targetID: String
+    var minutesBefore: Int
+    var isEnabled: Bool
+
+    init(
+        id: UUID = UUID(),
+        targetID: String,
+        minutesBefore: Int,
+        isEnabled: Bool = true
+    ) {
+        self.id = id
+        self.targetID = targetID
+        self.minutesBefore = minutesBefore
+        self.isEnabled = isEnabled
+    }
+}

--- a/Familienkalendar/FamilienkalendarApp.swift
+++ b/Familienkalendar/FamilienkalendarApp.swift
@@ -6,12 +6,31 @@
 //
 
 import SwiftUI
+import SwiftData
 
 @main
 struct FamilienkalenderApp: App {
+    private let sharedModelContainer: ModelContainer = {
+        let schema = Schema([
+            PersonModel.self,
+            CalendarEventModel.self,
+            RemoteFeedModel.self,
+            TaskItemModel.self,
+            ReminderRuleModel.self
+        ])
+
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        do {
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Konnte ModelContainer nicht erstellen: \(error)")
+        }
+    }()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(modelContext: sharedModelContainer.mainContext)
         }
+        .modelContainer(sharedModelContainer)
     }
 }

--- a/Familienkalendar/RemoteFeedStore.swift
+++ b/Familienkalendar/RemoteFeedStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SwiftData
+
+@MainActor
+struct RemoteFeedStore {
+    private let modelContext: ModelContext
+    private let legacyKey = "remoteICSFeeds"
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func migrateLegacyIfNeeded() throws {
+        let existing = try modelContext.fetch(FetchDescriptor<RemoteFeedModel>())
+        guard existing.isEmpty else {
+            return
+        }
+
+        guard
+            let data = UserDefaults.standard.data(forKey: legacyKey),
+            let feeds = try? JSONDecoder().decode([RemoteFeed].self, from: data)
+        else {
+            return
+        }
+
+        for feed in feeds {
+            modelContext.insert(
+                RemoteFeedModel(
+                    id: feed.id,
+                    name: feed.name,
+                    urlString: feed.urlString,
+                    isEnabled: feed.isEnabled
+                )
+            )
+        }
+
+        try modelContext.save()
+        UserDefaults.standard.removeObject(forKey: legacyKey)
+    }
+
+    func loadFeeds() throws -> [RemoteFeed] {
+        let descriptor = FetchDescriptor<RemoteFeedModel>(
+            sortBy: [SortDescriptor(\RemoteFeedModel.createdAt)]
+        )
+        let persisted = try modelContext.fetch(descriptor)
+        return persisted.map { model in
+            RemoteFeed(id: model.id, name: model.name, urlString: model.urlString, isEnabled: model.isEnabled)
+        }
+    }
+
+    func saveFeeds(_ feeds: [RemoteFeed]) throws {
+        let existing = try modelContext.fetch(FetchDescriptor<RemoteFeedModel>())
+        var existingByID: [String: RemoteFeedModel] = [:]
+        existing.forEach { existingByID[$0.id] = $0 }
+
+        let incomingIDs = Set(feeds.map(\.id))
+
+        for feed in feeds {
+            if let model = existingByID[feed.id] {
+                model.name = feed.name
+                model.urlString = feed.urlString
+                model.isEnabled = feed.isEnabled
+            } else {
+                modelContext.insert(
+                    RemoteFeedModel(
+                        id: feed.id,
+                        name: feed.name,
+                        urlString: feed.urlString,
+                        isEnabled: feed.isEnabled
+                    )
+                )
+            }
+        }
+
+        for model in existing where !incomingIDs.contains(model.id) {
+            modelContext.delete(model)
+        }
+
+        try modelContext.save()
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftData domain models for `Person`, `CalendarEvent`, `RemoteFeed`, `Task`, and `ReminderRule`
- initialize a shared `ModelContainer` in app startup and inject `ModelContext` into `ContentView`
- add `RemoteFeedStore` for SwiftData persistence
- migrate legacy `.ics` feed data from `UserDefaults` to SwiftData on first bootstrap
- switch remote feed persistence in `FamilyCalendarViewModel` from `UserDefaults` to SwiftData

## Why
This is the first implementation step for FK-001 (domain model + migration path from prototype persistence).

## Validation
- `xcodebuild -project Familienkalendar.xcodeproj -scheme Familienkalendar -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -quiet build`
- `xcodebuild -project Familienkalendar.xcodeproj -scheme Familienkalendar -configuration Debug -destination "generic/platform=macOS,variant=Mac Catalyst" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" -quiet build`